### PR TITLE
Verify zip sha256 during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,13 @@ ARG BW_CLI_VERSION
 
 RUN apt update && \
     apt install -y wget unzip && \
-    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip && \
-    unzip bw-oss-linux-${BW_CLI_VERSION}.zip && \
+    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-sha256-${BW_CLI_VERSION}.txt --no-verbose -O bw.zip.sha256 && \
+    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip --no-verbose -O bw.zip && \
+    echo "$(cat bw.zip.sha256) bw.zip" | sha256sum --check - && \
+    unzip bw.zip && \
     chmod +x bw && \
     mv bw /usr/local/bin/bw && \
-    rm -rfv *.zip
+    rm -rfv bw.zip.*
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
- Downloads the sha256 alongside the zip.
- Performs a sha256 check, fails the build if integrity is compromised.
- Adds `--no-verbose` to the `wget` commands. They bloated the output during build, without much added benefit in my opinion.

This is how the build will fail if there's a sha256 mismatch (I've rigged the checksum to simulate this):
```bash
# SNIP SNIP apt install output
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
2025-02-04 20:19:46 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/53538899/c53256bb-0c9a-427c-829c-c4428893e0ff?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250204%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250204T201946Z&X-Amz-Expires=300&X-Amz-Signature=834f91223c3a88b6eb323d56fda9d1a30222cfc4cd7ee58b95c77fcbc8444751&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dbw-oss-linux-sha256-2025.1.2.txt&response-content-type=application%2Foctet-stream [65/65] -> "bw.zip.sha256" [1]
2025-02-04 20:19:49 URL:https://objects.githubusercontent.com/github-production-release-asset-2e65be/53538899/9550908f-f40c-422a-a20e-89cac1b1d4d7?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20250204%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250204T201947Z&X-Amz-Expires=300&X-Amz-Signature=d3ba0804887ffa5842c3affcfa1930667181de6164a3d8534983f711c6b9f1a1&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3Dbw-oss-linux-2025.1.2.zip&response-content-type=application%2Foctet-stream [36526862/36526862] -> "bw.zip" [1]
bw.zip: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
The command '/bin/sh -c apt update &&     apt install -y wget unzip &&     wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-sha256-${BW_CLI_VERSION}.txt --no-verbose -O bw.zip.sha256 &&     wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip --no-verbose -O bw.zip &&     echo "ad739858696336371b26c676e1ee00bbd49070ad61fe8af7558d86f7baaa6ed5 bw.zip" | sha256sum --check - &&     unzip bw.zip &&     chmod +x bw &&     mv bw /usr/local/bin/bw &&     rm -rfv *.zip' returned a non-zero code: 1
```