### PR TITLE
fix: `rm` glob expression not matching the downloaded zip archive 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt update && \
     unzip bw.zip && \
     chmod +x bw && \
     mv bw /usr/local/bin/bw && \
-    rm -rfv bw.zip.*
+    rm -rfv bw.zip*
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
In my previous PR (https://github.com/charlesthomas/bitwarden-cli/pull/1), I made a typo in the `rm` glob expression, resulting in the `bw.zip` blob sticking around in the final image layers. This inflated the image size by ~35MB, from 273MB, to 309MB (`before-fix` being https://github.com/charlesthomas/bitwarden-cli/commit/d41cdf72f1c9710caeab1c57d17b2c5b9f482177, and `after-fix` being [this branch](https://github.com/charlesthomas/bitwarden-cli/commit/0a4e20ff0e2f32c3db28ca2e96700a5956cc6c29)):
```bash
docker image ls | grep fix
after-fix                                  latest                       8c25763decb1   9 minutes ago    273MB
before-fix                                 latest                       034f9f071845   11 minutes ago   309MB
```

The `rm` glob expression should be `bw.zip*` instead of `bw.zip.*`, my bad :smiley:  ! 

This PR addresses the above issue.