### PR TITLE
Security and style improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt update && \
 COPY entrypoint.sh /
 USER bw
 WORKDIR /bw
+ENV HOME=/bw
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:sid
 ARG BW_CLI_VERSION
 
 RUN apt update && \
-    apt install -y wget unzip && \
+    apt install -y tini unzip wget && \
     wget "https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-sha256-${BW_CLI_VERSION}.txt" --no-verbose -O bw.zip.sha256 && \
     wget "https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip" --no-verbose -O bw.zip && \
     echo "$(cat bw.zip.sha256) bw.zip" | sha256sum --check - && \
@@ -14,4 +14,5 @@ RUN apt update && \
 
 COPY entrypoint.sh /
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG BW_CLI_VERSION
 
 RUN apt update && \
     apt install -y tini unzip wget && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* && \
     wget "https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-sha256-${BW_CLI_VERSION}.txt" --no-verbose -O bw.zip.sha256 && \
     wget "https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip" --no-verbose -O bw.zip && \
     echo "$(cat bw.zip.sha256) bw.zip" | sha256sum --check - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG BW_CLI_VERSION
 
 RUN apt update && \
     apt install -y wget unzip && \
-    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-sha256-${BW_CLI_VERSION}.txt --no-verbose -O bw.zip.sha256 && \
-    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip --no-verbose -O bw.zip && \
+    wget "https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-sha256-${BW_CLI_VERSION}.txt" --no-verbose -O bw.zip.sha256 && \
+    wget "https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip" --no-verbose -O bw.zip && \
     echo "$(cat bw.zip.sha256) bw.zip" | sha256sum --check - && \
     unzip bw.zip && \
     chmod +x bw && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,17 @@ RUN apt update && \
     unzip bw.zip && \
     chmod +x bw && \
     mv bw /usr/local/bin/bw && \
-    rm -rfv bw.zip*
+    rm -rfv bw.zip* && \
+    mkdir /bw && \
+    groupadd --gid 1000 bw && \
+    useradd --system --uid 1000 --no-create-home --shell /bin/false --home /bw --gid 1000 bw && \
+    echo "bw:supersecret" | chpasswd && \
+    chown -R bw:0 /bw && \
+    chmod -R g=u /bw
 
 COPY entrypoint.sh /
+USER bw
+WORKDIR /bw
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,5 @@ export BW_SESSION
 
 bw unlock --check
 
-bw serve --hostname 0.0.0.0 #--disable-origin-protection
-echo "Running `bw server` on port 8087"
+echo "Running \`bw server\` on port 8087"
+exec bw serve --hostname 0.0.0.0 #--disable-origin-protection

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,11 +2,12 @@
 
 set -e
 
-bw config server ${BW_HOST}
+bw config server "${BW_HOST}"
 
-export BW_SESSION=$(bw login ${BW_USER} --passwordenv BW_PASSWORD --raw)
+BW_SESSION=$(bw login "${BW_USER}" --passwordenv BW_PASSWORD --raw)
+export BW_SESSION
 
 bw unlock --check
 
-echo 'Running `bw server` on port 8087'
 bw serve --hostname 0.0.0.0 #--disable-origin-protection
+echo "Running `bw server` on port 8087"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 bw config server "${BW_HOST}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# If the container crashed there may be a dangling config file, remove it before reconfiguring.
+# Not deleting it will result in a "Logout required before server config update." error.
+[ -f "${BITWARDENCLI_APPDATA_DIR}/data.json" ] && rm -f "${BITWARDENCLI_APPDATA_DIR}/data.json"
 bw config server "${BW_HOST}"
 
 BW_SESSION=$(bw login "${BW_USER}" --passwordenv BW_PASSWORD --raw)


### PR DESCRIPTION
Hi there!

I wanted to use this image in a K8s deployment where our CIS hardening usually requires us to use non-root containers and failed. As it seems unlikely that the BW CLI needs root permissions, I went ahead and made some changes to support this.

In addition, I fixed some issues violating good container practices or offended shellcheck. Also, using a `/bw` folder will allow folks to even use a read-only root filesystem, using an ephemeral directory for it (as the BW CLI itself should be pretty much stateless).

Looking forward to your review! :smile: 

P.S.: Pushed a build to `ghcr.io/poikilotherm/bitwarden-cli:improve` for easy testing.