### PR TITLE
feat: add option to log in with apikey

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,9 +4,17 @@ set -e
 
 bw config server ${BW_HOST}
 
-export BW_SESSION=$(bw login ${BW_USER} --passwordenv BW_PASSWORD --raw)
+if [ -n "$BW_CLIENTID" ] && [ -n "$BW_CLIENTSECRET" ]; then
+	echo "Using apikey to log in"
+	bw login --apikey --raw
+	export BW_SESSION=$(bw unlock --passwordenv BW_PASSWORD --raw)
+else
+	echo "Using username and password to log in"
+	export BW_SESSION=$(bw login ${BW_USER} --passwordenv BW_PASSWORD --raw)
+fi
 
 bw unlock --check
 
 echo 'Running `bw server` on port 8087'
 bw serve --hostname 0.0.0.0 #--disable-origin-protection
+


### PR DESCRIPTION
I had some issues with being prompted to enter a verification code sent to my email when trying to log in with username and password, thus I added the option to log in via apikey. The password is still needed to unlock the vault.

Contributing back as this is the image referenced from the [external-secrets](https://external-secrets.io/latest/examples/bitwarden/) example. 