### PR TITLE
Add arm64 support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,6 +43,10 @@ jobs:
               git push --delete origin $VERSION
             fi
           done
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -60,6 +64,7 @@ jobs:
           build-args: BW_VERSION=${{ env.BW_VERSION }}
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/charlesthomas/bitwarden-cli:${{ env.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Create tag

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -43,6 +43,10 @@ jobs:
               git push --delete origin $VERSION
             fi
           done
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
@@ -60,6 +64,7 @@ jobs:
           build-args: BW_VERSION=${{ env.BW_VERSION }}
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/charlesthomas/bitwarden-cli:${{ env.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Create tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM debian:sid
 
 ARG BW_CLI_VERSION=2025.12.1
+ARG TARGETARCH
 
 RUN apt update && \
     apt install -y wget unzip && \
-    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux-${BW_CLI_VERSION}.zip && \
-    unzip bw-oss-linux-${BW_CLI_VERSION}.zip && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+      BW_ARCH="-arm64"; \
+    else \
+      BW_ARCH=""; \
+    fi && \
+    wget https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-oss-linux${BW_ARCH}-${BW_CLI_VERSION}.zip && \
+    unzip bw-oss-linux${BW_ARCH}-${BW_CLI_VERSION}.zip && \
     chmod +x bw && \
     mv bw /usr/local/bin/bw && \
     rm -rfv *.zip


### PR DESCRIPTION
This PR serves to add ARM64 support in the dockerfile.

I considered adding it to the workflow, and I (and others) would appreciate that if you do decide to do so. 
I decided against doing so due to increased cost on your end for building arm images.

Edit: I added the commit of workflow builds. You're welcome to remove that if you would like, I just thought I would give a convenient option. I turned on edits for this PR, so you should be able to do so. Cheers!!