### PR TITLE
Fix build-arg name mismatch causing 2026.x.y tags to ship hardcoded 2025.12.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
-          build-args: BW_VERSION=${{ env.BW_VERSION }}
+          build-args: BW_CLI_VERSION=${{ env.BW_VERSION }}
           context: .
           push: true
           tags: ghcr.io/charlesthomas/bitwarden-cli:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:sid
 
-ARG BW_CLI_VERSION=2025.12.1
+ARG BW_CLI_VERSION
 
 RUN apt update && \
     apt install -y wget unzip && \


### PR DESCRIPTION
Fixes #9.

The workflow passes `BW_VERSION=${{ env.BW_VERSION }}` but the Dockerfile declares `ARG BW_CLI_VERSION`. Docker silently discards undeclared `--build-arg` values, so every build since `01a00c9` has fallen back to the hardcoded default `2025.12.1` regardless of what's in the `VERSION` file. The `2026.1.0`, `2026.2.0`, and `2026.3.0` published images all contain the `2025.12.1` `bw` binary inside.

Two changes:

- **`.github/workflows/main.yaml`**: pass `BW_CLI_VERSION=${{ env.BW_VERSION }}` so the value reaches the Dockerfile under the name it expects.
- **`Dockerfile`**: drop the hardcoded default so a missing build-arg fails the build immediately rather than silently regressing future tags.

Net change: 2 files, 2 lines. Issue #9 has the full analysis (commit history, Docker semantics, repro). Once this lands, `VERSION`-based releases will produce images with matching `bw` binaries.